### PR TITLE
Fix malloc, free, cmalloc

### DIFF
--- a/src/compat/malloc.rs
+++ b/src/compat/malloc.rs
@@ -3,23 +3,30 @@ use core::alloc::{GlobalAlloc, Layout};
 use crate::ALLOCATOR;
 
 pub unsafe extern "C" fn malloc(size: u32) -> *const u8 {
-    // FIXME: what is the correct value for `alignment`?
-    ALLOCATOR.alloc(Layout::from_size_align_unchecked(size as usize, 1))
+    log::trace!("alloc {}", size);
+    
+    let total_size = size as usize + 4;
+    let ptr = ALLOCATOR.alloc(Layout::from_size_align_unchecked(total_size, 4));
+    *(ptr as *mut _ as *mut usize) = total_size;
+    ptr.offset(4)
 }
 
 pub unsafe extern "C" fn free(ptr: *const u8) {
-    ALLOCATOR.dealloc(ptr as *mut u8, Layout::for_value_raw(ptr));
+    log::trace!("free {:p}", ptr);
+    
+    let ptr = ptr.offset(-4);
+    let total_size = *(ptr as *const usize);
+    ALLOCATOR.dealloc(ptr as *mut u8, Layout::from_size_align_unchecked(total_size, 4));
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn calloc(number: u32, size: u32) -> *const u8 {
-    // FIXME: what is the correct value for `alignment`?
-    let mut ptr = ALLOCATOR.alloc(Layout::from_size_align_unchecked(size as usize, 1)) as *mut u8;
+    log::trace!("calloc {} {}", number, size);
 
-    for _ in 0..(number * size) {
-        ptr.write_volatile(0xFF);
-        ptr = ptr.offset(1);
-    }
+    let total_size = (number * size) as usize + 4;
+    let ptr = ALLOCATOR.alloc(Layout::from_size_align_unchecked(total_size, 4)) as *mut u8;
+    core::ptr::write_bytes::<u8>(ptr, 0u8, total_size);
+    *(ptr as *mut _ as *mut usize) = total_size;
 
-    ptr as *const u8
+    ptr.offset(4) as *const u8
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub(crate) static ALLOCATOR: esp_alloc::EspHeap = esp_alloc::EspHeap::empty();
 pub fn init_heap() {
     use core::mem::MaybeUninit;
 
-    const HEAP_SIZE: usize = 4 * 1024;
+    const HEAP_SIZE: usize = 64 * 1024;
     static mut HEAP: [MaybeUninit<u8>; HEAP_SIZE] = [MaybeUninit::uninit(); HEAP_SIZE];
 
     unsafe {


### PR DESCRIPTION
This makes allocations work at least for the already adapted ESP32C3-DHCP example.

Not sure why it needs that much memory - probably it's fine and the same as before - needs to be checked.
At least one step forward